### PR TITLE
Fix addFile file handling and update README import

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ go get golang.org/x/net/context
 Put the package under your project folder and add the following in import:
 
 ```go
-import openapi "github.com/pussikill/yandex-market-go-client"
+import openapi "github.com/ucoms-dev/yandex-market-go-client"
 ```
 
 To use a proxy, set the environment variable `HTTP_PROXY`:

--- a/client.go
+++ b/client.go
@@ -606,14 +606,11 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 
 // Add a file to the multipart request
 func addFile(w *multipart.Writer, fieldName, path string) error {
-	file, err := os.Open(filepath.Clean(path))
-	if err != nil {
-		return err
-	}
-	err = file.Close()
-	if err != nil {
-		return err
-	}
+        file, err := os.Open(filepath.Clean(path))
+        if err != nil {
+                return err
+        }
+        defer file.Close()
 
 	part, err := w.CreateFormFile(fieldName, filepath.Base(path))
 	if err != nil {


### PR DESCRIPTION
## Summary
- fix README import path to `github.com/ucoms-dev/yandex-market-go-client`
- keep the file open while copying in `addFile`

## Testing
- `go test ./...` *(fails: connect: no route to host)*