### PR TITLE
Fix OrderDeliveryAddressDTO fields

### DIFF
--- a/docs/OrderDeliveryAddressDTO.md
+++ b/docs/OrderDeliveryAddressDTO.md
@@ -9,10 +9,12 @@ Name | Type | Description | Notes
 **City** | Pointer to **string** | Город или населенный пункт.  | [optional] 
 **District** | Pointer to **string** | Район. | [optional] 
 **Subway** | Pointer to **string** | Станция метро. | [optional] 
-**Street** | Pointer to **string** | Улица.  | [optional] 
-**House** | Pointer to **string** | Дом или владение.  | [optional] 
-**Block** | Pointer to **string** | Корпус или строение. | [optional] 
-**Entrance** | Pointer to **string** | Подъезд. | [optional] 
+**Street** | Pointer to **string** | Улица.  | [optional]
+**House** | Pointer to **string** | Дом или владение.  | [optional]
+**Estate** | Pointer to **string** | Номер владения. | [optional]
+**Building** | Pointer to **string** | Номер строения. | [optional]
+**Block** | Pointer to **string** | Корпус или строение. | [optional]
+**Entrance** | Pointer to **string** | Подъезд. | [optional]
 **Entryphone** | Pointer to **string** | Код домофона. | [optional] 
 **Floor** | Pointer to **string** | Этаж. | [optional] 
 **Apartment** | Pointer to **string** | Квартира или офис. | [optional] 
@@ -213,6 +215,56 @@ SetHouse sets House field to given value.
 `func (o *OrderDeliveryAddressDTO) HasHouse() bool`
 
 HasHouse returns a boolean if a field has been set.
+
+### GetEstate
+
+`func (o *OrderDeliveryAddressDTO) GetEstate() string`
+
+GetEstate returns the Estate field if non-nil, zero value otherwise.
+
+### GetEstateOk
+
+`func (o *OrderDeliveryAddressDTO) GetEstateOk() (*string, bool)`
+
+GetEstateOk returns a tuple with the Estate field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEstate
+
+`func (o *OrderDeliveryAddressDTO) SetEstate(v string)`
+
+SetEstate sets Estate field to given value.
+
+### HasEstate
+
+`func (o *OrderDeliveryAddressDTO) HasEstate() bool`
+
+HasEstate returns a boolean if a field has been set.
+
+### GetBuilding
+
+`func (o *OrderDeliveryAddressDTO) GetBuilding() string`
+
+GetBuilding returns the Building field if non-nil, zero value otherwise.
+
+### GetBuildingOk
+
+`func (o *OrderDeliveryAddressDTO) GetBuildingOk() (*string, bool)`
+
+GetBuildingOk returns a tuple with the Building field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetBuilding
+
+`func (o *OrderDeliveryAddressDTO) SetBuilding(v string)`
+
+SetBuilding sets Building field to given value.
+
+### HasBuilding
+
+`func (o *OrderDeliveryAddressDTO) HasBuilding() bool`
+
+HasBuilding returns a boolean if a field has been set.
 
 ### GetBlock
 

--- a/model_order_delivery_address_dto.go
+++ b/model_order_delivery_address_dto.go
@@ -33,6 +33,10 @@ type OrderDeliveryAddressDTO struct {
 	Street *string `json:"street,omitempty"`
 	// Дом или владение.
 	House *string `json:"house,omitempty"`
+	// Номер владения.
+	Estate *string `json:"estate,omitempty"`
+	// Номер строения.
+	Building *string `json:"building,omitempty"`
 	// Корпус или строение.
 	Block *string `json:"block,omitempty"`
 	// Подъезд.
@@ -289,6 +293,70 @@ func (o *OrderDeliveryAddressDTO) HasHouse() bool {
 // SetHouse gets a reference to the given string and assigns it to the House field.
 func (o *OrderDeliveryAddressDTO) SetHouse(v string) {
 	o.House = &v
+}
+
+// GetEstate returns the Estate field value if set, zero value otherwise.
+func (o *OrderDeliveryAddressDTO) GetEstate() string {
+	if o == nil || IsNil(o.Estate) {
+		var ret string
+		return ret
+	}
+	return *o.Estate
+}
+
+// GetEstateOk returns a tuple with the Estate field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *OrderDeliveryAddressDTO) GetEstateOk() (*string, bool) {
+	if o == nil || IsNil(o.Estate) {
+		return nil, false
+	}
+	return o.Estate, true
+}
+
+// HasEstate returns a boolean if a field has been set.
+func (o *OrderDeliveryAddressDTO) HasEstate() bool {
+	if o != nil && !IsNil(o.Estate) {
+		return true
+	}
+
+	return false
+}
+
+// SetEstate gets a reference to the given string and assigns it to the Estate field.
+func (o *OrderDeliveryAddressDTO) SetEstate(v string) {
+	o.Estate = &v
+}
+
+// GetBuilding returns the Building field value if set, zero value otherwise.
+func (o *OrderDeliveryAddressDTO) GetBuilding() string {
+	if o == nil || IsNil(o.Building) {
+		var ret string
+		return ret
+	}
+	return *o.Building
+}
+
+// GetBuildingOk returns a tuple with the Building field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *OrderDeliveryAddressDTO) GetBuildingOk() (*string, bool) {
+	if o == nil || IsNil(o.Building) {
+		return nil, false
+	}
+	return o.Building, true
+}
+
+// HasBuilding returns a boolean if a field has been set.
+func (o *OrderDeliveryAddressDTO) HasBuilding() bool {
+	if o != nil && !IsNil(o.Building) {
+		return true
+	}
+
+	return false
+}
+
+// SetBuilding gets a reference to the given string and assigns it to the Building field.
+func (o *OrderDeliveryAddressDTO) SetBuilding(v string) {
+	o.Building = &v
 }
 
 // GetBlock returns the Block field value if set, zero value otherwise.
@@ -577,6 +645,12 @@ func (o OrderDeliveryAddressDTO) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.House) {
 		toSerialize["house"] = o.House
+	}
+	if !IsNil(o.Estate) {
+		toSerialize["estate"] = o.Estate
+	}
+	if !IsNil(o.Building) {
+		toSerialize["building"] = o.Building
 	}
 	if !IsNil(o.Block) {
 		toSerialize["block"] = o.Block


### PR DESCRIPTION
## Summary
- add `Estate` and `Building` fields to `OrderDeliveryAddressDTO`
- document new fields and methods

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871401e887c832991e75d1487a1b6c2