### PR TITLE
Fix buyer email parsing

### DIFF
--- a/docs/OrderBuyerDTO.md
+++ b/docs/OrderBuyerDTO.md
@@ -5,10 +5,11 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | Pointer to **string** | Идентификатор покупателя. | [optional] 
-**LastName** | Pointer to **string** | Фамилия покупателя. | [optional] 
-**FirstName** | Pointer to **string** | Имя покупателя. | [optional] 
-**MiddleName** | Pointer to **string** | Отчество покупателя. | [optional] 
-**Type** | [**OrderBuyerType**](OrderBuyerType.md) |  | 
+**LastName** | Pointer to **string** | Фамилия покупателя. | [optional]
+**FirstName** | Pointer to **string** | Имя покупателя. | [optional]
+**Email** | Pointer to **string** | Электронная почта покупателя. | [optional]
+**MiddleName** | Pointer to **string** | Отчество покупателя. | [optional]
+**Type** | [**OrderBuyerType**](OrderBuyerType.md) |  |
 
 ## Methods
 
@@ -103,6 +104,31 @@ SetFirstName sets FirstName field to given value.
 `func (o *OrderBuyerDTO) HasFirstName() bool`
 
 HasFirstName returns a boolean if a field has been set.
+
+### GetEmail
+
+`func (o *OrderBuyerDTO) GetEmail() string`
+
+GetEmail returns the Email field if non-nil, zero value otherwise.
+
+### GetEmailOk
+
+`func (o *OrderBuyerDTO) GetEmailOk() (*string, bool)`
+
+GetEmailOk returns a tuple with the Email field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmail
+
+`func (o *OrderBuyerDTO) SetEmail(v string)`
+
+SetEmail sets Email field to given value.
+
+### HasEmail
+
+`func (o *OrderBuyerDTO) HasEmail() bool`
+
+HasEmail returns a boolean if a field has been set.
 
 ### GetMiddleName
 

--- a/docs/OrderBuyerInfoDTO.md
+++ b/docs/OrderBuyerInfoDTO.md
@@ -6,9 +6,10 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | Pointer to **string** | Идентификатор покупателя. | [optional] 
 **LastName** | Pointer to **string** | Фамилия покупателя. | [optional] 
-**FirstName** | Pointer to **string** | Имя покупателя. | [optional] 
-**MiddleName** | Pointer to **string** | Отчество покупателя. | [optional] 
-**Type** | [**OrderBuyerType**](OrderBuyerType.md) |  | 
+**FirstName** | Pointer to **string** | Имя покупателя. | [optional]
+**Email** | Pointer to **string** | Электронная почта покупателя. | [optional]
+**MiddleName** | Pointer to **string** | Отчество покупателя. | [optional]
+**Type** | [**OrderBuyerType**](OrderBuyerType.md) |  |
 **Phone** | Pointer to **string** | Подменный номер телефона покупателя. Подробнее о таких номерах читайте [в Справке Маркета для продавцов](https://yandex.ru/support2/marketplace/ru/orders/dbs/call#fake-number).  Формат номера: &#x60;+&lt;код_страны&gt;&lt;код_региона&gt;&lt;номер_телефона&gt;&#x60;.  | [optional] 
 **Trusted** | Pointer to **bool** | Проверенный покупатель.  Если параметр &#x60;trusted&#x60; вернулся со значением &#x60;true&#x60;, Маркет уже проверил покупателя — не звоните ему. Обработайте заказ как обычно и передайте его курьеру или отвезите в ПВЗ.  При необходимости свяжитесь с покупателем в чате. [Как это сделать](../../step-by-step/chats.md)  Подробнее о звонках покупателю читайте [в Справке Маркета для продавцов](https://yandex.ru/support/marketplace/ru/orders/dbs/call).  | [optional] 
 
@@ -105,6 +106,31 @@ SetFirstName sets FirstName field to given value.
 `func (o *OrderBuyerInfoDTO) HasFirstName() bool`
 
 HasFirstName returns a boolean if a field has been set.
+
+### GetEmail
+
+`func (o *OrderBuyerInfoDTO) GetEmail() string`
+
+GetEmail returns the Email field if non-nil, zero value otherwise.
+
+### GetEmailOk
+
+`func (o *OrderBuyerInfoDTO) GetEmailOk() (*string, bool)`
+
+GetEmailOk returns a tuple with the Email field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEmail
+
+`func (o *OrderBuyerInfoDTO) SetEmail(v string)`
+
+SetEmail sets Email field to given value.
+
+### HasEmail
+
+`func (o *OrderBuyerInfoDTO) HasEmail() bool`
+
+HasEmail returns a boolean if a field has been set.
 
 ### GetMiddleName
 

--- a/model_order_buyer_dto.go
+++ b/model_order_buyer_dto.go
@@ -27,6 +27,8 @@ type OrderBuyerDTO struct {
 	LastName *string `json:"lastName,omitempty"`
 	// Имя покупателя.
 	FirstName *string `json:"firstName,omitempty"`
+	// Электронная почта покупателя.
+	Email *string `json:"email,omitempty"`
 	// Отчество покупателя.
 	MiddleName *string        `json:"middleName,omitempty"`
 	Type       OrderBuyerType `json:"type"`
@@ -148,6 +150,38 @@ func (o *OrderBuyerDTO) SetFirstName(v string) {
 	o.FirstName = &v
 }
 
+// GetEmail returns the Email field value if set, zero value otherwise.
+func (o *OrderBuyerDTO) GetEmail() string {
+	if o == nil || IsNil(o.Email) {
+		var ret string
+		return ret
+	}
+	return *o.Email
+}
+
+// GetEmailOk returns a tuple with the Email field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *OrderBuyerDTO) GetEmailOk() (*string, bool) {
+	if o == nil || IsNil(o.Email) {
+		return nil, false
+	}
+	return o.Email, true
+}
+
+// HasEmail returns a boolean if a field has been set.
+func (o *OrderBuyerDTO) HasEmail() bool {
+	if o != nil && !IsNil(o.Email) {
+		return true
+	}
+
+	return false
+}
+
+// SetEmail gets a reference to the given string and assigns it to the Email field.
+func (o *OrderBuyerDTO) SetEmail(v string) {
+	o.Email = &v
+}
+
 // GetMiddleName returns the MiddleName field value if set, zero value otherwise.
 func (o *OrderBuyerDTO) GetMiddleName() string {
 	if o == nil || IsNil(o.MiddleName) {
@@ -222,6 +256,9 @@ func (o OrderBuyerDTO) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.FirstName) {
 		toSerialize["firstName"] = o.FirstName
+	}
+	if !IsNil(o.Email) {
+		toSerialize["email"] = o.Email
 	}
 	if !IsNil(o.MiddleName) {
 		toSerialize["middleName"] = o.MiddleName

--- a/model_order_buyer_info_dto.go
+++ b/model_order_buyer_info_dto.go
@@ -27,6 +27,8 @@ type OrderBuyerInfoDTO struct {
 	LastName *string `json:"lastName,omitempty"`
 	// Имя покупателя.
 	FirstName *string `json:"firstName,omitempty"`
+	// Электронная почта покупателя.
+	Email *string `json:"email,omitempty"`
 	// Отчество покупателя.
 	MiddleName *string        `json:"middleName,omitempty"`
 	Type       OrderBuyerType `json:"type"`
@@ -150,6 +152,38 @@ func (o *OrderBuyerInfoDTO) HasFirstName() bool {
 // SetFirstName gets a reference to the given string and assigns it to the FirstName field.
 func (o *OrderBuyerInfoDTO) SetFirstName(v string) {
 	o.FirstName = &v
+}
+
+// GetEmail returns the Email field value if set, zero value otherwise.
+func (o *OrderBuyerInfoDTO) GetEmail() string {
+	if o == nil || IsNil(o.Email) {
+		var ret string
+		return ret
+	}
+	return *o.Email
+}
+
+// GetEmailOk returns a tuple with the Email field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *OrderBuyerInfoDTO) GetEmailOk() (*string, bool) {
+	if o == nil || IsNil(o.Email) {
+		return nil, false
+	}
+	return o.Email, true
+}
+
+// HasEmail returns a boolean if a field has been set.
+func (o *OrderBuyerInfoDTO) HasEmail() bool {
+	if o != nil && !IsNil(o.Email) {
+		return true
+	}
+
+	return false
+}
+
+// SetEmail gets a reference to the given string and assigns it to the Email field.
+func (o *OrderBuyerInfoDTO) SetEmail(v string) {
+	o.Email = &v
 }
 
 // GetMiddleName returns the MiddleName field value if set, zero value otherwise.
@@ -290,6 +324,9 @@ func (o OrderBuyerInfoDTO) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.FirstName) {
 		toSerialize["firstName"] = o.FirstName
+	}
+	if !IsNil(o.Email) {
+		toSerialize["email"] = o.Email
 	}
 	if !IsNil(o.MiddleName) {
 		toSerialize["middleName"] = o.MiddleName


### PR DESCRIPTION
## Summary
- include `email` field in `OrderBuyerDTO` and `OrderBuyerInfoDTO`
- document the new field in model docs

## Testing
- `go build ./...` *(fails: proxy connection blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68714d3d69988329947b4433c4b33906